### PR TITLE
Update packages and .NET, remove unused using of Swan

### DIFF
--- a/src/Artemis.Plugins.Modules.LogiStats/Artemis.Plugins.Modules.LogiStats.csproj
+++ b/src/Artemis.Plugins.Modules.LogiStats/Artemis.Plugins.Modules.LogiStats.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Platforms>x64</Platforms>
         <EnableDynamicLoading>true</EnableDynamicLoading>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ArtemisRGB.UI.Shared" IncludeAssets="compile;build;buildTransitive" Version="1.2024.228.5" />
-        <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.2" />
+        <PackageReference Include="ArtemisRGB.UI.Shared" IncludeAssets="compile;build;buildTransitive" Version="1.2025.216.4" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Artemis.Plugins.Modules.LogiStats/LogiStatsModule.cs
+++ b/src/Artemis.Plugins.Modules.LogiStats/LogiStatsModule.cs
@@ -2,7 +2,6 @@ using Artemis.Core.Modules;
 using Artemis.Plugins.Modules.LogiStats.DataModels;
 using Microsoft.Data.Sqlite;
 using Serilog;
-using Swan;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
The latest Artemis update removed EmbedIO and the Swan library that came with it. This plugin has a (unused) reference to Swan so I removed it.